### PR TITLE
Move most dependencies to devDependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,14 +23,14 @@
   ],
   "license": "Apache 2.0",
   "dependencies": {
-    "angular": "1.2.15",
-    "json3": "~3.2.6",
-    "bootstrap-sass-official": "3.2.0",
-    "es5-shim": "~2.1.0",
-    "jquery": "components/jquery#~2.1.1"
+    "angular": "1.2.15"
   },
   "devDependencies": {
     "angular-mocks": "1.2.15",
-    "angular-scenario": "1.2.15"
+    "angular-scenario": "1.2.15",
+    "bootstrap-sass-official": "3.2.0",
+    "es5-shim": "~2.1.0",
+    "jquery": "components/jquery#~2.1.1",
+    "json3": "~3.2.6"
   }
 }


### PR DESCRIPTION
The distribution copy of json-formatter in lib/ doesn't depend on anything but Angular (as far as I can tell), so avoid installing things we won't need (e.g. boostrap-sass-official) when using json-formatter in another project.
