### PR TITLE
Bugfix - update type when updating value.

### DIFF
--- a/src/json-formatter.js
+++ b/src/json-formatter.js
@@ -91,6 +91,7 @@ angular.module('jsonFormatter', ['RecursionHelper'])
     };
 
     scope.parseValue = function (value){
+      scope.type = typeof scope.json;
       if (scope.type === 'null') {
         return 'null';
       }


### PR DESCRIPTION
In my app a value changes from `"sample1"` to `false`.

It changes the type from `string` to `boolean`. 

This caused an error: 

Before: An error is thrown, because `escapeString` cannot escape a boolean (i.e. booleans don't have a `replace` function)
After: No error is thrown.
