### PR TITLE
Update bower.json to include dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,11 @@
     "test",
     "tests"
   ],
+  "dependencies": {
+    "angular": "~1.4.4",
+    "angular-sanitize": "~1.4.4",
+    "jquery": "~2.1.1"
+  }
   "devDependencies": {
     "angular": "~1.4.4",
     "angular-mocks": "~1.4.4",

--- a/bower.json
+++ b/bower.json
@@ -23,10 +23,8 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.4.4",
-    "angular-sanitize": "~1.4.4",
-    "jquery": "~2.1.1"
-  }
+    "angular": "~1.4.4"
+  },
   "devDependencies": {
     "angular": "~1.4.4",
     "angular-mocks": "~1.4.4",


### PR DESCRIPTION
Bower client build order isn't setup correctly, because this package doesn't indicate that it needs angular and jquery to be defined on the page before it can be included.