### PR TITLE
Added a watch on 'open' for dynamic open changes

### DIFF
--- a/src/json-formatter.js
+++ b/src/json-formatter.js
@@ -196,6 +196,14 @@ angular.module('jsonFormatter', ['RecursionHelper'])
         return '{' + kvs.join(', ') + ellipsis + '}';
       }
     };
+
+    if (typeof scope.watchOpen == 'undefined') {
+      // Singleton
+      scope.watchOpen = true;
+      scope.$watch('open', function(value) {
+        scope.isOpen = !!scope.open;
+      }, false);    
+    }
   }
 
   return {


### PR DESCRIPTION
This is a simple change to implement [#34](https://github.com/mohsen1/json-formatter/issues/34).  I am a little green at some of this stuff so this may not be the best approach.  I tested the changes with simple collapse all/none buttons and they seemed to work well--redrew the content when a button was pressed.