### PR TITLE
feature: title attribute

### DIFF
--- a/demo/demo.html
+++ b/demo/demo.html
@@ -210,6 +210,11 @@
       <json-formatter open="1" json='person'></json-formatter>
     </div>
 
+    <h4>Custom title</h4>
+    <div class="result">
+      <json-formatter json='deep' title="DeepObj"></json-formatter>
+    </div>
+
     <h4><code>ng-repeat</code></h4>
     <p>If you are iterating in an array of objects, make sure you are using <code>track by $index</code> to avoid adding extra <code>$$hashKey</code> to your objects.</p>
     <h5>With <code>track by $index</code></h5>

--- a/src/json-formatter.html
+++ b/src/json-formatter.html
@@ -4,7 +4,10 @@
     <span class="key" ng-if="hasKey"><span class="key-text">{{key}}</span><span class="colon">:</span></span>
     <span class="value">
       <span ng-if="isObject()">
-        <span class="constructor-name">{{getConstructorName(json)}}</span>
+        <span class="json-title" ng-if="!!title" ng-bind="title"></span>
+        <span ng-if="!title">
+          <span class="constructor-name">{{getConstructorName(json)}}</span>
+        </span>
         <span ng-if="isArray()"><span class="bracket">[</span><span class="number">{{json.length}}</span><span class="bracket">]</span></span>
       </span>
       <span ng-if="!isObject()" ng-click="openLink(isUrl)" class="{{type}}" ng-class="{date: isDate, url: isUrl}">{{parseValue(json)}}</span>

--- a/src/json-formatter.js
+++ b/src/json-formatter.js
@@ -102,7 +102,7 @@ angular.module('jsonFormatter', ['RecursionHelper'])
     return value;
   }
 
-  function link(scope) {
+  function link(scope, elem, attrs) {
     scope.isArray = function () {
       return angular.isArray(scope.json);
     };
@@ -143,6 +143,9 @@ angular.module('jsonFormatter', ['RecursionHelper'])
         scope.isOpen && !scope.isArray();
     };
 
+    if (!!attrs.title) {
+      scope.title = attrs.title;
+    }
 
     // If 'open' attribute is present
     scope.isOpen = !!scope.open;

--- a/test/json-formatter.spec.js
+++ b/test/json-formatter.spec.js
@@ -3,12 +3,12 @@
 describe('json-formatter', function () {
   var scope, $compile, $rootScope, element, fakeModule, JSONFormatterConfig;
 
-  function createDirective(key, open) {
+  function createDirective(key, open, title) {
     open = open === undefined ? 0 : open;
+    title = title === undefined ? '' : title;
     var elm;
-    var template = '<json-formatter json="' + key + '" open="' + open +
+    var template = '<json-formatter json="' + key + '" open="' + open + '" title="' + title +
       '"></json-formatter>';
-
     elm = angular.element(template);
     angular.element(document.body).prepend(elm);
     scope._null = null;
@@ -240,6 +240,12 @@ describe('json-formatter', function () {
           element = createDirective('simpleObject', 0);
           expect(element.find('.thumbnail-text').text().trim()).toBe('{me:1}');
         });
+
+        it('should render "simple object with title Mobile"', function () {
+          element = createDirective('simpleObject', 0, 'Mobile');
+          expect(element.find('.json-title').text().trim()).toBe('Mobile');
+        });
+
 
         it('should render "longer object"', function () {
           element = createDirective('longerObject', 0);


### PR DESCRIPTION

```html
   <json-formatter json="{my: 'json'}" open="1" title="TestObj"></json-formatter>
```
So the title 'TestObj' can replace 'Object'. It can be useful when create constructor for json value is not easy(ex: json value returned from API or hash from other source)