### PR TITLE
Use a caret modified for Angular version.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,12 +23,12 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.4.4"
+    "angular": "^1.4.4"
   },
   "devDependencies": {
-    "angular": "~1.4.4",
-    "angular-mocks": "~1.4.4",
-    "angular-sanitize": "~1.4.4",
+    "angular": "^1.4.4",
+    "angular-mocks": "^1.4.4",
+    "angular-sanitize": "^1.4.4",
     "bootstrap": "~3.3.5",
     "jquery": "~2.1.1"
   }


### PR DESCRIPTION
This should allow the package to be used with Angular 1.5, without bower
warnings.

Resolves #46.