### PR TITLE
Update licence field to Apache-2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": {
     "name": "Mohsen Azimi"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "devDependencies": {
     "chai": "^3.2.0",
     "del": "^1.2.0",


### PR DESCRIPTION
Fix the license filed in ```package.json``` from MIT to Apache-2.0.